### PR TITLE
Adding Aldp Boltzmann distribution

### DIFF
--- a/fab/target_distributions/__init__.py
+++ b/fab/target_distributions/__init__.py
@@ -1,2 +1,3 @@
 from fab.target_distributions.gmm import GMM
 from fab.target_distributions.many_well import ManyWellEnergy
+from fab.target_distributions.aldp import AldpBoltzmann

--- a/fab/target_distributions/aldp.py
+++ b/fab/target_distributions/aldp.py
@@ -1,0 +1,79 @@
+import torch
+from torch import nn
+
+from fab.target_distributions.base import TargetDistribution
+
+import boltzgen as bg
+from simtk import openmm as mm
+from simtk import unit
+from simtk.openmm import app
+from openmmtools import testsystems
+import mdtraj
+
+
+
+class AldpBoltzmann(nn.Module, TargetDistribution):
+    def __init__(self, data_path, temperature=1000, energy_cut=1.e+8, energy_max=1.e+20, n_threads=4):
+        super(AldpBoltzmann, self).__init__()
+        # Define molecule parameters
+        ndim = 66
+        z_matrix = [
+            (0, [1, 4, 6]),
+            (1, [4, 6, 8]),
+            (2, [1, 4, 0]),
+            (3, [1, 4, 0]),
+            (4, [6, 8, 14]),
+            (5, [4, 6, 8]),
+            (7, [6, 8, 4]),
+            (11, [10, 8, 6]),
+            (12, [10, 8, 11]),
+            (13, [10, 8, 11]),
+            (15, [14, 8, 16]),
+            (16, [14, 8, 6]),
+            (17, [16, 14, 15]),
+            (18, [16, 14, 8]),
+            (19, [18, 16, 14]),
+            (20, [18, 16, 19]),
+            (21, [18, 16, 19])
+        ]
+        cart_indices = [6, 8, 9, 10, 14]
+
+        # System setup
+        system = testsystems.AlanineDipeptideVacuum(constraints=None)
+        sim = app.Simulation(system.topology, system.system,
+                             mm.LangevinIntegrator(temperature * unit.kelvin,
+                                                   1. / unit.picosecond,
+                                                   1. * unit.femtosecond),
+                             mm.Platform.getPlatformByName('Reference'))
+
+        # Load data for transform
+        traj = mdtraj.load(data_path)
+        traj.center_coordinates()
+
+        # superpose on the backbone
+        ind = traj.top.select("backbone")
+        traj.superpose(traj, 0, atom_indices=ind, ref_atom_indices=ind)
+
+        # Gather the training data into a pytorch Tensor with the right shape
+        transform_data = traj.xyz
+        n_atoms = transform_data.shape[1]
+        n_dim = n_atoms * 3
+        transform_data_npy = transform_data.reshape(-1, n_dim)
+        transform_data = torch.from_numpy(transform_data_npy.astype("float64"))
+
+        # Set distribution
+        self.coordinate_transform = bg.flows.CoordinateTransform(transform_data, ndim,
+                                                                 z_matrix, cart_indices)
+
+        if n_threads > 1:
+            self.p = bg.distributions.TransformedBoltzmannParallel(system, temperature,
+                                                                   energy_cut=energy_cut, energy_max=energy_max,
+                                                                   transform=self.coordinate_transform,
+                                                                   n_threads=n_threads)
+        else:
+            self.p = bg.distributions.TransformedBoltzmann(sim.context, temperature,
+                                                           energy_cut=energy_cut, energy_max=energy_max,
+                                                           transform=self.coordinate_transform)
+
+    def log_prob(self, x: torch.tensor):
+        return self.p.log_prob(x)

--- a/fab/target_distributions/aldp_test.py
+++ b/fab/target_distributions/aldp_test.py
@@ -1,0 +1,69 @@
+import torch
+import numpy as np
+
+from simtk import openmm as mm
+from simtk import unit
+from simtk.openmm import app
+from openmmtools.testsystems import AlanineDipeptideVacuum
+import mdtraj
+import tempfile
+
+from fab.target_distributions.aldp import AldpBoltzmann
+
+
+
+def test_aldp():
+    # Generate a trajectory for coordinate transform
+    temperature = 1000
+    testsystem = AlanineDipeptideVacuum(constraints=None)
+    vacuum_sim = app.Simulation(testsystem.topology,
+                                testsystem.system,
+                                mm.LangevinIntegrator(temperature * unit.kelvin, 1.0 / unit.picosecond,
+                                                      1.0 * unit.femtosecond),
+                                platform=mm.Platform.getPlatformByName('CPU'))
+    vacuum_sim.context.setPositions(testsystem.positions)
+    vacuum_sim.minimizeEnergy()
+    tmp_dir = tempfile.gettempdir()
+    data_path = tmp_dir + '/aldp.h5'
+    vacuum_sim.reporters.append(mdtraj.reporters.HDF5Reporter(data_path, 10))
+    vacuum_sim.step(10000)
+    del(vacuum_sim)
+
+    # Create distribution
+    aldp_boltz = AldpBoltzmann(data_path)
+
+    # Load test data
+    traj = mdtraj.load(data_path)
+    traj.center_coordinates()
+
+    # superpose on the backbone
+    ind = traj.top.select("backbone")
+    traj.superpose(traj, 0, atom_indices=ind, ref_atom_indices=ind)
+
+    # Gather the training data into a pytorch Tensor with the right shape
+    test_data = traj.xyz
+    n_atoms = test_data.shape[1]
+    n_dim = n_atoms * 3
+    test_data_npy = test_data.reshape(-1, n_dim)
+    test_data = torch.from_numpy(test_data_npy.astype("float64"))
+
+    # Transform coordinates
+    x_test, log_det = aldp_boltz.coordinate_transform.inverse(test_data[::20])
+
+    # Compute probability
+    logp = aldp_boltz.log_prob(x_test)
+    logp_np = logp.cpu().numpy()
+
+    # Tests
+    assert logp.shape == (50,)
+    assert np.all(logp_np < -200)
+    assert np.all(logp_np > -300)
+
+    # Print sample values
+    print("Log prob transformed Boltzmann distribution")
+    print(logp)
+    print("Log prob Boltzmann distribution")
+    print(logp + log_det)
+
+    
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy
 torch
-git+https://github.com/VincentStimper/normalizing-flows.git
+normflow @ git+https://github.com/VincentStimper/normalizing-flows.git
+boltzgen @ git+https://github.com/VincentStimper/boltzmann-generators.git
 nflows
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ numpy
 torch
 normflow @ git+https://github.com/VincentStimper/normalizing-flows.git
 boltzgen @ git+https://github.com/VincentStimper/boltzmann-generators.git
+mdtraj
 nflows
 tqdm


### PR DESCRIPTION
I added the Boltzmann distribution of the Alanine Dipeptide and it seems to work fine, see testing. To get is running, you need to [install](http://docs.openmm.org/latest/userguide/application/01_getting_started.html#installing-openmm) `openmm` and `openmmtools`, while the former is only available of Python 3.7 or earlier, as well as `mdtraj` and my Boltzmann generator library, which I already added to the requirements file.