### PR TITLE
3 more losses

### DIFF
--- a/examples/double_well.ipynb
+++ b/examples/double_well.ipynb
@@ -83,7 +83,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fab.target_distributions import ManyWellEnergy\n",
+    "from fab.target_distributions.many_well import ManyWellEnergy\n",
     "assert dim % 2 == 0\n",
     "target = ManyWellEnergy(dim, a=-0.5, b=-6)\n",
     "plotting_bounds = (-3, 3)"

--- a/examples/double_well.ipynb
+++ b/examples/double_well.ipynb
@@ -240,8 +240,6 @@
    },
    "outputs": [],
    "source": [
-    "# the nan's that arrise during the training are typically extreme flow samples (e.g. x=[100, 100]), \n",
-    "# which give Nan values for the target density. However, these do not harm long term training.\n",
     "trainer.run(n_iterations=n_iterations, batch_size=batch_size, n_plot=n_plots, \\\n",
     "            n_eval=n_eval, eval_batch_size=eval_batch_size)"
    ]

--- a/examples/fab_various_targets.py
+++ b/examples/fab_various_targets.py
@@ -40,13 +40,13 @@ def train_fab(
         eval_batch_size = None
         assert dim == 2
     elif target_name == "GMM":
-        from fab.target_distributions import GMM
+        from fab.target_distributions.gmm import GMM
         target = GMM(dim, n_mixes=5, min_cov=1, loc_scaling=5)
         plotting_bounds = (-20, 20)
         n_eval = 100
         eval_batch_size = batch_size * 10
     elif target_name == "ManyWell":
-        from fab.target_distributions import ManyWellEnergy
+        from fab.target_distributions.many_well import ManyWellEnergy
         assert dim % 2 == 0
         target = ManyWellEnergy(dim, a=-0.5, b=-6)
         plotting_bounds = (-3, 3)

--- a/examples/gmm.ipynb
+++ b/examples/gmm.ipynb
@@ -83,7 +83,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fab.target_distributions import GMM\n",
+    "from fab.target_distributions.gmm import GMM\n",
     "torch.manual_seed(seed)\n",
     "target = GMM(dim=dim, n_mixes=4, min_cov=1, loc_scaling=10)\n",
     "plotting_bounds = (-30, 30)"

--- a/examples/many_well_16.ipynb
+++ b/examples/many_well_16.ipynb
@@ -176,7 +176,7 @@
   {
    "cell_type": "code",
    "source": [
-    "from fab.target_distributions import ManyWellEnergy\n",
+    "from fab.target_distributions.many_well import ManyWellEnergy\n",
     "assert dim % 2 == 0\n",
     "target = ManyWellEnergy(dim, a=-0.5, b=-6)\n",
     "plotting_bounds = (-3, 3)"

--- a/fab/core.py
+++ b/fab/core.py
@@ -46,8 +46,6 @@ class FABModel(Model):
             return self.fab_forward_kl(batch_size)
         elif self.loss_type == "sample_log_prob":
             return self.fab_sample_log_prob(batch_size)
-        elif self.loss_type == "log_expected_prob":
-            return self.fab_log_expected_prob(batch_size)
         else:
             raise NotImplementedError
 

--- a/fab/core.py
+++ b/fab/core.py
@@ -18,7 +18,10 @@ class FABModel(Model):
                  n_intermediate_distributions: int,
                  transition_operator: Optional[TransitionOperator],
                  ais_distribution_spacing: "str" = "linear",
+                 loss_type: "str" = "alpha_2_div",
                  ):
+        assert loss_type in ["alpha_2_div", "forward_kl", "sample_log_prob"]
+        self.loss_type = loss_type
         self.flow = flow
         self.target_distribution = target_distribution
         self.n_intermediate_distributions = n_intermediate_distributions
@@ -37,29 +40,24 @@ class FABModel(Model):
         return self.flow.parameters()
 
     def loss(self, batch_size: int) -> torch.Tensor:
-        # return self.fab_forward_kl(batch_size)
-        return self.fab_alpha_div_loss(batch_size)
-
+        if self.loss_type == "alpha_2_div":
+            return self.fab_alpha_div_loss(batch_size)
+        elif self.loss_type == "forward_kl":
+            return self.fab_sample_log_prob(batch_size)
+        elif self.loss_type == "sample_log_prob":
+            return self.fab_sample_log_prob(batch_size)
+        else:
+            raise NotImplementedError
 
     def fab_alpha_div_loss(self, batch_size: int) -> torch.Tensor:
         """Compute the FAB loss based on lower-bound of alpha-divergence with alpha=2."""
         x_ais, log_w_ais = self.annealed_importance_sampler.sample_and_log_weights(batch_size)
         x_ais = x_ais.detach()
         log_w_ais = log_w_ais.detach()
-        # Estimate log_Z_N where N is the number of samples and Z is the target's normalisation
-        # constant to adjust target log probability with. This is to keeping the learning stable
-        # (so that we don't have an implicit Z or N constant in the loss that is dependant on the
-        # specific target or batch size).
-        log_Z_N = torch.logsumexp(log_w_ais, dim=0)
-        log_w_AIS_normalised = log_w_ais - log_Z_N
         log_q_x = self.flow.log_prob(x_ais)
         log_p_x = self.target_distribution.log_prob(x_ais)
-        # TODO: we may want to investigate using a running average for log_Z to normalise log_p_x.
-        # N = log_w_ais.shape[0]
-        # log_p_x = self.target_distribution.log_prob(x_ais) - log_Z
-        # log_Z = log_Z_N - torch.log(torch.ones_like(log_Z_N) * N)
         log_w = log_p_x - log_q_x
-        return torch.logsumexp(log_w_AIS_normalised + log_w, dim=0)
+        return torch.logsumexp(log_w_ais + log_w, dim=0)
 
 
     def fab_forward_kl(self, batch_size: int) -> torch.Tensor:
@@ -67,10 +65,14 @@ class FABModel(Model):
         x_ais, log_w_ais = self.annealed_importance_sampler.sample_and_log_weights(batch_size)
         x_ais = x_ais.detach()
         log_w_ais = log_w_ais.detach()
-        log_Z_N = torch.logsumexp(log_w_ais, dim=0)
-        log_w_AIS_normalised = log_w_ais - log_Z_N
         log_q_x = self.flow.log_prob(x_ais)
-        return - torch.mean(torch.exp(log_w_AIS_normalised) * log_q_x)
+        return - torch.mean(torch.exp(log_w_ais) * log_q_x)
+
+    def fab_sample_log_prob(self, batch_size: int) -> torch.Tensor:
+        """Compute FAB loss by maximising the log prob of ais samples under the flow."""
+        x_ais, log_w_ais = self.annealed_importance_sampler.sample_and_log_weights(batch_size)
+        log_q_x = self.flow.log_prob(x_ais.detach())
+        return - torch.mean(log_q_x)
 
     def get_iter_info(self) -> Dict[str, Any]:
         return self.annealed_importance_sampler.get_logging_info()

--- a/fab/core.py
+++ b/fab/core.py
@@ -43,9 +43,11 @@ class FABModel(Model):
         if self.loss_type == "alpha_2_div":
             return self.fab_alpha_div_loss(batch_size)
         elif self.loss_type == "forward_kl":
-            return self.fab_sample_log_prob(batch_size)
+            return self.fab_forward_kl(batch_size)
         elif self.loss_type == "sample_log_prob":
             return self.fab_sample_log_prob(batch_size)
+        elif self.loss_type == "log_expected_prob":
+            return self.fab_log_expected_prob(batch_size)
         else:
             raise NotImplementedError
 

--- a/fab/target_distributions/__init__.py
+++ b/fab/target_distributions/__init__.py
@@ -1,0 +1,1 @@
+from base import TargetDistribution

--- a/fab/target_distributions/__init__.py
+++ b/fab/target_distributions/__init__.py
@@ -1,4 +1,0 @@
-from fab.target_distributions.base import TargetDistribution
-from fab.target_distributions.gmm import GMM
-from fab.target_distributions.many_well import ManyWellEnergy
-from fab.target_distributions.aldp import AldpBoltzmann

--- a/fab/target_distributions/__init__.py
+++ b/fab/target_distributions/__init__.py
@@ -1,1 +1,0 @@
-from base import TargetDistribution

--- a/fab/target_distributions/many_well.py
+++ b/fab/target_distributions/many_well.py
@@ -3,7 +3,7 @@ from fab.types_ import LogProbFunc
 
 import torch
 import torch.nn as nn
-from fab.target_distributions import TargetDistribution
+from fab.target_distributions.base import TargetDistribution
 
 class Energy(torch.nn.Module):
     """


### PR DESCRIPTION
- Remove normalising of log weights from FAB losses. Adam should be invariant to this scaling, so estimating the normalising constant and scaling the weights by it for each mini-batch will just add unnecessary noise. This also makes the FAB alpha-2-divergence loss more simple/legible. 
- Add more losses: 
   - (1) AIS weighted estimate of the forward KL divergence
   - (2) Maximising the log prob of samples generated by AIS
- Remove target distribution imports from the `__init__` so that the repository doesn't require openmm etc to be installed if the dipeptide problem is not being used (this makes it easier to run the Many Well example in colab / on a cluster without having to do extra installs). 

I have tested the new losses on the double well problem and they work (ESS & test set log prob go up throughout training), but perform less well than the alpha-2-divergence loss. However they may be useful for running comparisons, and loss (2) may be useful early in training when the AIS weights have very high variance. 

I did a single run with loss (2) on the 16-dim many problem and it performed a lot worse (mode hugging) - however this was just a single run so could be that it requires different hyper-parameter settings. I will do comparisons of all 3 losses over the weekend. 