### PR TITLE
Add hmc mass matrix

### DIFF
--- a/examples/visualise_ais.ipynb
+++ b/examples/visualise_ais.ipynb
@@ -1,0 +1,439 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1cd25370",
+   "metadata": {},
+   "source": [
+    "# Visualise AIS\n",
+    "In this notebook we perform some visualisations of the annealed sampling algorithms performance, such as how AIS scales with the number of intermediate distributions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb056a44",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.insert(0, \"../\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57471d83",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "from fab.sampling_methods import AnnealedImportanceSampler, Metropolis, HamiltoneanMonteCarlo\n",
+    "from fab.utils.logging import ListLogger\n",
+    "from fab.target_distributions import TargetDistribution\n",
+    "from fab.target_distributions.gmm import GMM\n",
+    "from fab.wrappers.torch import WrappedTorchDist\n",
+    "from fab.utils.plotting import plot_history, plot_contours, plot_marginal_pair\n",
+    "from fab.utils.numerical import effective_sample_size"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8585fc4c",
+   "metadata": {},
+   "source": [
+    "## Setup Target Distribution & AIS based distribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad8c304a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dim: int = 2\n",
+    "seed: int = 1\n",
+    "transition_operator_type: str = \"hmc\"\n",
+    "torch.manual_seed(seed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04cbf84e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target = GMM(dim=dim, n_mixes=4, loc_scaling=8)\n",
+    "base_dist = WrappedTorchDist(torch.distributions.MultivariateNormal(loc=torch.zeros(dim),\n",
+    "                                                                 scale_tril=15*torch.eye(dim)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e419b72e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot target\n",
+    "plot_contours(target.log_prob, bounds=[-20, 20], n_contour_levels=50)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5bedb02a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot base distribution\n",
+    "base_samples = base_dist.sample((500,))\n",
+    "plot_marginal_pair(base_samples, bounds=[-40, 40])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76cbbcde",
+   "metadata": {},
+   "source": [
+    "## Setup example of AIS\n",
+    "First we run look at the effect of tuning the step size for a fixed number of intermediate distributions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d408902c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_ais_dist = 5 \n",
+    "batch_size = 1000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b3b32a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def setup_ais(n_ais_intermediate_distributions, transition_operator_type,\n",
+    "             step_size_init=1.0, n_outer=5):\n",
+    "    if transition_operator_type == \"hmc\":\n",
+    "        transition_operator = HamiltoneanMonteCarlo(\n",
+    "            n_ais_intermediate_distributions=n_ais_intermediate_distributions,\n",
+    "            n_outer=n_outer,\n",
+    "            epsilon=step_size_init, L=5, dim=dim,\n",
+    "            step_tuning_method=\"p_accept\") # other tuning options include \"No-U\" and \"Expected_target_prob\"\n",
+    "    elif transition_operator_type == \"metropolis\":\n",
+    "        transition_operator = Metropolis(n_transitions=n_ais_intermediate_distributions,\n",
+    "                                         n_updates=5)\n",
+    "    ais = AnnealedImportanceSampler(base_distribution=base_dist,\n",
+    "                                    target_log_prob=target.log_prob,\n",
+    "                                    transition_operator=transition_operator,\n",
+    "                                    n_intermediate_distributions=n_ais_intermediate_distributions,\n",
+    "                                    )\n",
+    "    return ais"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bc2dd45c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# we give epsilon a poor initialisation so we can visualise the effect of tuning easily\n",
+    "ais = setup_ais(n_ais_dist, \"hmc\", step_size_init=10.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa62d979",
+   "metadata": {},
+   "source": [
+    "### Visualise samples before HMC has been tuned. \n",
+    "Note that we have given epsilone a poor initialisation (too big)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d4f5094",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ais.transition_operator.set_eval_mode(True) # turn off tuning"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72c2af86",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "samples, log_w = ais.sample_and_log_weights(batch_size)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b87692e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "plot_contours(target.log_prob, ax=ax, bounds=[-30, 30], n_contour_levels=50)\n",
+    "plot_marginal_pair(samples, ax=ax, bounds=[-30, 30])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca81b5de",
+   "metadata": {},
+   "source": [
+    "### Tune HMC and visualise again.\n",
+    "We see that the effective sample size (after ais) goes up during the tuning), and that the samples match the target more closely. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f647f6c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logger = ListLogger()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a126619",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ais.transition_operator.set_eval_mode(False) # turn on tuning"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee25032d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def eval(ais, outer_batch_size, inner_batch_size):\n",
+    "    ais.transition_operator.set_eval_mode(True) # turn off tuning for evaluation.\n",
+    "    base_samples, base_log_w, ais_samples, ais_log_w = \\\n",
+    "        ais.generate_eval_data(outer_batch_size, inner_batch_size)\n",
+    "    info = {\"eval_ess_base\": effective_sample_size(log_w=base_log_w, normalised=False).item(),\n",
+    "            \"eval_ess_ais\": effective_sample_size(log_w=ais_log_w, normalised=False).item()}\n",
+    "    ais.transition_operator.set_eval_mode(False) # turn on tuning\n",
+    "    return info"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ead8af97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in tqdm(range(100)):\n",
+    "    samples, log_w = ais.sample_and_log_weights(batch_size)\n",
+    "    logging_info = ais.get_logging_info()\n",
+    "    logger.write(logging_info)\n",
+    "    if i % 10 == 0:\n",
+    "        eval_info = eval(ais, 20*batch_size, batch_size)\n",
+    "        logger.write(eval_info)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "517d0a2e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "plot_contours(target.log_prob, ax=ax, bounds=[-30, 30], n_contour_levels=50)\n",
+    "plot_marginal_pair(samples, ax=ax, bounds=[-30, 30])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1832815e",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "plot_history(logger.history)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5dc20770",
+   "metadata": {},
+   "source": [
+    "## Visualise the effect of the number of AIS distributions\n",
+    "We see that as the number of AIS distributions increases, the effective sample size increases, and the variance in the importance log weights decreases."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5d3171c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "range_n_distributions = [2, 4, 8, 16, 32, 64, 128]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af279c4e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logger = ListLogger()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe3909e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ess_hist = []\n",
+    "for n_ais_dist in tqdm(range_n_distributions):\n",
+    "    # turn off step size tuning, initial step size is reasonable and we only want to visualise the effect of \n",
+    "    # the number of ais distributions. \n",
+    "    ais = setup_ais(n_ais_dist, \"hmc\", step_size_init=1.0, n_outer=1)\n",
+    "    ais.transition_operator.set_eval_mode(True) \n",
+    "    base_samples, base_log_w, ais_samples, ais_log_w = \\\n",
+    "        ais.generate_eval_data(50*batch_size, batch_size)\n",
+    "    info = {\"eval_ess_ais\": effective_sample_size(log_w=ais_log_w, normalised=False).item(),\n",
+    "           \"log_w_var\": torch.var(ais_log_w).item()}\n",
+    "    logger.write(info)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99f94ba1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axs = plt.subplots(2)\n",
+    "axs[0].plot(range_n_distributions, logger.history[\"eval_ess_ais\"])\n",
+    "axs[0].set_ylabel(\"effective sample size\")\n",
+    "axs[0].set_xlabel(\"number of intermediate ais distributions\")\n",
+    "\n",
+    "axs[1].plot(range_n_distributions, logger.history[\"log_w_var\"])\n",
+    "axs[1].set_ylabel(\"var log w\")\n",
+    "axs[1].set_xlabel(\"number of intermediate ais distributions\")\n",
+    "axs[1].set_yscale(\"log\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66efd21c",
+   "metadata": {},
+   "source": [
+    "The log variance initialy decreases by a huge amount, however as the number of AIS distributions increases, the log variance decreases more closely to a rate of 1/n. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "910ea02b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logger.history['log_w_var']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3eefd88e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's look at samples after a the max number of AIS steps. \n",
+    "fig, axs = plt.subplots(1, 2, figsize=(15, 5))\n",
+    "plot_contours(target.log_prob, ax=axs[0], bounds=[-30, 30], n_contour_levels=50)\n",
+    "plot_marginal_pair(ais_samples[:1000], ax=axs[0], bounds=[-30, 30])\n",
+    "axs[0].set_title(\"samples (ais) vs target contours\")\n",
+    "\n",
+    "plot_contours(target.log_prob, ax=axs[1], bounds=[-30, 30], n_contour_levels=50)\n",
+    "plot_marginal_pair(target.sample((1000,)), ax=axs[1], bounds=[-30, 30])\n",
+    "axs[1].set_title(\"samples (target) vs target contours\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "edb8e87d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# and for comparison with only a few intermediate distributions\n",
+    "n_ais_dist = 4 # change this number to see how the number of distributions effects the samples from AIS.\n",
+    "ais_2_dist = setup_ais(n_ais_dist, \"hmc\", step_size_init=1.0, n_outer=1)\n",
+    "\n",
+    "fig, axs = plt.subplots(1, 2, figsize=(15, 5))\n",
+    "plot_contours(target.log_prob, ax=axs[0], bounds=[-30, 30], n_contour_levels=50)\n",
+    "plot_marginal_pair(ais_2_dist.sample_and_log_weights(batch_size)[0], ax=axs[0], bounds=[-30, 30])\n",
+    "axs[0].set_title(\"samples (ais) vs target contours\")\n",
+    "\n",
+    "plot_contours(target.log_prob, ax=axs[1], bounds=[-30, 30], n_contour_levels=50)\n",
+    "plot_marginal_pair(target.sample((1000,)), ax=axs[1], bounds=[-30, 30])\n",
+    "axs[1].set_title(\"samples (target) vs target contours\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c767274",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/fab/sampling_methods/ais_test.py
+++ b/fab/sampling_methods/ais_test.py
@@ -6,7 +6,8 @@ import matplotlib.pyplot as plt
 
 from fab.sampling_methods import AnnealedImportanceSampler, Metropolis, HamiltoneanMonteCarlo
 from fab.utils.logging import ListLogger
-from fab.target_distributions import GMM, TargetDistribution
+from fab.target_distributions import TargetDistribution
+from fab.target_distributions.gmm import GMM
 from fab.wrappers.torch import WrappedTorchDist
 from fab.utils.plotting import plot_history
 

--- a/fab/sampling_methods/transition_operators/hmc.py
+++ b/fab/sampling_methods/transition_operators/hmc.py
@@ -1,5 +1,7 @@
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
+from typing import Union
 
 from fab.sampling_methods.transition_operators.base import TransitionOperator
 from fab.types_ import LogProbFunc
@@ -11,15 +13,30 @@ class HamiltoneanMonteCarlo(TransitionOperator):
                  dim: int,
                  epsilon: float = 1.0,
                  n_outer: int = 1,
-                 L: int =5,
+                 L: int = 5,
+                 mass_init: Union[float, torch.Tensor] = 1.0,
                  step_tuning_method: str = "p_accept",
                  target_p_accept: float = 0.65,
                  lr: float = 1e-3,
                  tune_period: bool = False,
                  common_epsilon_init_weight: float = 0.1,
                  max_grad: float = 1e3):
+        """
+        The options for the step_uning_method are as follows:
+            - p_accept: Tune the step size (epsilon) to obtain an average acceptance probability of
+                65%.
+            - No-U-unscaled: Maximise expected distance moved, using gradient descent based on
+                the last HMC inner step.
+            - No-U: Like No-U-unscaled with scaling of the distance moved according to the standard
+                deviation of samples w.r.t each dimension.
+                Following ideas from https://arxiv.org/pdf/1711.09268.pdf.
+            - Expected_target_prob: Maximise the expected target prob by gradient descent, from
+                http://proceedings.mlr.press/v139/campbell21a/campbell21a.pdf
+        """
         super(HamiltoneanMonteCarlo, self).__init__()
         assert step_tuning_method in HMC_STEP_TUNING_METHODS
+        if isinstance(mass_init, torch.Tensor):
+            assert mass_init.shape == (dim, )  # check mass_init dim is correct if a vector
         self.dim = dim
         self.tune_period = tune_period
         self.max_grad = max_grad
@@ -27,6 +44,7 @@ class HamiltoneanMonteCarlo(TransitionOperator):
         if step_tuning_method in ["Expected_target_prob", "No-U", "No-U-unscaled"]:
             self.train_params = True
             self.counter = 0
+            self.mass_vector = nn.ParameterDict()
             self.epsilons = nn.ParameterDict()
             self.epsilons["common"] = nn.Parameter(
                 torch.log(torch.tensor([epsilon])) * common_epsilon_init_weight)
@@ -35,15 +53,18 @@ class HamiltoneanMonteCarlo(TransitionOperator):
                 for n in range(n_outer):
                     self.epsilons[f"{i}_{n}"] = nn.Parameter(torch.log(
                         torch.ones(dim)*epsilon*(1 - common_epsilon_init_weight)))
+                    self.mass_vector[f"{i}_{n}"] = nn.Parameter(torch.ones(dim) * mass_init)
             if self.step_tuning_method == "No-U":
                 self.register_buffer("characteristic_length",
                                      torch.ones(n_ais_intermediate_distributions, dim))
-            self.optimizer = torch.optim.AdamW(self.parameters(), lr=lr)
+            self.optimizer = torch.optim.Adam(self.parameters(), lr=lr)
         else:
             self.train_params = False
+            # we weakly tie the step size parameters by utilising a shared component.
             self.register_buffer("common_epsilon", torch.tensor([epsilon * common_epsilon_init_weight]))
             self.register_buffer("epsilons", torch.ones([n_ais_intermediate_distributions, n_outer]) * epsilon *
                                  (1 - common_epsilon_init_weight))
+            self.register_buffer("mass_vector", torch.ones(dim) * mass_init)
         self.n_outer = n_outer
         self.L = L
         self.n_intermediate_ais_distributions = n_ais_intermediate_distributions
@@ -60,70 +81,93 @@ class HamiltoneanMonteCarlo(TransitionOperator):
             for i, val in enumerate(self.last_dist_p_accepts):
                 interesting_dict[f"dist{self.n_intermediate_ais_distributions - 1}_p_accept_{i}"]\
                     = val.item()
-        epsilon_first_dist_first_loop = self.get_epsilon(0,0)
+        epsilon_first_dist_first_loop = self.get_epsilon(0, 0)
+        mass_first_dist_first_loop = self.get_mass(0, 0)
         if epsilon_first_dist_first_loop.numel() == 1:
             interesting_dict[f"epsilons_dist0_loop0"] = epsilon_first_dist_first_loop.cpu().item()
         else:
             interesting_dict[f"epsilons_dist0_0_dim0"] = epsilon_first_dist_first_loop[0].cpu().item()
             interesting_dict[f"epsilons_dist0_0_dim-1"] = epsilon_first_dist_first_loop[-1].cpu().item()
+        interesting_dict[f"mass_dist0_0_dim0"] = mass_first_dist_first_loop[0].cpu().item()
+        interesting_dict[f"mass_dist0_0_dim-1"] = mass_first_dist_first_loop[-1].cpu().item()
+
         if self.n_intermediate_ais_distributions > 1:
             last_dist_n = self.n_intermediate_ais_distributions - 1
             epsilon_last_dist_first_loop = self.get_epsilon(last_dist_n, 0)
+            mass_last_dist_first_loop = self.get_mass(last_dist_n, 0)
             if epsilon_last_dist_first_loop.numel() == 1:
                 interesting_dict[f"epsilons_dist{last_dist_n}_loop0"] = epsilon_last_dist_first_loop.cpu().item()
             else:
                 interesting_dict[f"epsilons_dist{last_dist_n}_0_dim0"] = epsilon_last_dist_first_loop[0].cpu().item()
                 interesting_dict[f"epsilons_dist{last_dist_n}_0_dim-1"] = epsilon_last_dist_first_loop[-1].cpu().item()
 
+            interesting_dict[f"mass_dist{last_dist_n}_0_dim0"] = mass_last_dist_first_loop[0].cpu().item()
+            interesting_dict[f"mass_dist{last_dist_n}_0_dim-1"] = mass_last_dist_first_loop[-1].cpu().item()
+
         interesting_dict["average_distance"] = self.average_distance.cpu().item()
         return interesting_dict
 
-    def get_epsilon(self, i, n):
+    def get_epsilon(self, i: int, n: int) -> torch.Tensor:
         if self.train_params:
             return torch.exp(self.epsilons[f"{i}_{n}"]) + torch.exp(self.epsilons["common"])
         else:
             return self.epsilons[i, n] + self.common_epsilon
 
 
-    def HMC_func(self, U, current_q, grad_U, i):
+    def get_mass(self, i: int, n: int) -> torch.Tensor:
+        """The HMC mass (or Metric) hyper-parameter, of the same length as the
+        dimension of the position vector."""
+        if self.train_params:
+            return F.softplus(self.mass_vector[f"{i}_{n}"])
+        else:
+            return self.mass_vector
+
+
+    def HMC_func(self, U, current_theta, grad_U, i):
         if self.step_tuning_method == "Expected_target_prob":
             # need this for grad function
-            current_q = current_q.clone().detach().requires_grad_(True)
-            current_q = torch.clone(current_q)  # so we can do in place operations, kinda weird hac
+            current_theta = current_theta.clone().detach().requires_grad_(True)
+            current_theta = torch.clone(current_theta)  # so we can do in place operations, kinda weird hac
         else:
-            current_q = current_q.detach()  # otherwise just need to block grad flow
+            current_theta = current_theta.detach()  # otherwise just need to block grad flow
         loss = 0
         # need this for grad function
         # base function for HMC written in terms of potential energy function U
         for n in range(self.n_outer):
-            original_q = torch.clone(current_q).detach()
+            original_theta = torch.clone(current_theta).detach()
             if self.train_params:
                 self.optimizer.zero_grad()
             epsilon = self.get_epsilon(i, n).detach()
-            q = current_q
-            p = torch.randn_like(q)
+            mass_matrix = self.get_mass(i, n).detach()
+            theta = current_theta
+            p = torch.randn_like(theta) * mass_matrix
             current_p = p
             # make momentum half step
-            p = p - epsilon * grad_U(q) / 2
+            p = p - epsilon * grad_U(theta) / 2
 
             # Now loop through position and momentum leapfrogs
             for l in range(self.L):
                 epsilon = self.get_epsilon(i, n)
-                if (l != self.L - 1 and self.step_tuning_method in ["No-U", "No-U-unscaled"]) or not self.train_params:
+                mass_matrix = self.get_mass(i, n)
+                if not self.step_tuning_method == "Expected_target_prob":
+                    # TODO: for No-U based method need to add tuning
+                    mass_matrix = mass_matrix.detach()
+                if (l != self.L - 1 and self.step_tuning_method in ["No-U", "No-U-unscaled"]) or\
+                        not self.train_params:
                     epsilon = epsilon.detach()
                 # Make full step for position
-                q = q + epsilon * p
+                theta = theta + epsilon / mass_matrix * p
                 # Make a full step for the momentum if not at end of trajectory
                 if l != self.L-1:
-                    p = p - epsilon * grad_U(q)
+                    p = p - epsilon * grad_U(theta)
 
             # make a half step for momentum at the end
-            p = p - epsilon * grad_U(q) / 2
+            p = p - epsilon * grad_U(theta) / 2
             # Negate momentum at end of trajectory to make proposal symmetric
             p = -p
 
-            U_current = U(current_q)
-            U_proposed = U(q)
+            U_current = U(current_theta)
+            U_proposed = U(theta)
             current_K = torch.sum(current_p**2, dim=-1) / 2
             proposed_K = torch.sum(p**2, dim=-1) / 2
 
@@ -136,8 +180,8 @@ class HamiltoneanMonteCarlo(TransitionOperator):
                                                       posinf=0.0,
                                                       neginf=0.0)
             acceptance_probability = torch.clamp(acceptance_probability, min=0.0, max=1.0)
-            accept = acceptance_probability > torch.rand(acceptance_probability.shape).to(q.device)
-            current_q[accept] = q[accept]
+            accept = acceptance_probability > torch.rand(acceptance_probability.shape).to(theta.device)
+            current_theta[accept] = theta[accept]
             p_accept = torch.mean(acceptance_probability)
             if self.step_tuning_method == "p_accept":
                 if p_accept > self.target_p_accept: # too much accept
@@ -161,7 +205,7 @@ class HamiltoneanMonteCarlo(TransitionOperator):
                 self.last_dist_p_accepts[n] = torch.mean(acceptance_probability).cpu().detach()
 
             if i == 0 or self.step_tuning_method == "No-U-unscaled":
-                distance = torch.linalg.norm((original_q - current_q), ord=2, dim=-1)
+                distance = torch.linalg.norm((original_theta - current_theta), ord=2, dim=-1)
                 if i == 0:
                     self.average_distance = torch.mean(distance).detach().cpu()
                 if self.step_tuning_method == "No-U-unscaled":
@@ -170,7 +214,7 @@ class HamiltoneanMonteCarlo(TransitionOperator):
                     weighted_mean_square_distance = acceptance_probability * distance ** 2
                     loss = loss - torch.mean(weighted_mean_square_distance)
             if self.step_tuning_method == "No-U":
-                distance_scaled = torch.linalg.norm((original_q - current_q) / self.characteristic_length[i, :], ord=2, dim=-1)
+                distance_scaled = torch.linalg.norm((original_theta - current_theta) / self.characteristic_length[i, :], ord=2, dim=-1)
                 weighted_scaled_mean_square_distance = acceptance_probability * distance_scaled ** 2
                 if (self.tune_period is False or self.counter < self.tune_period) and self.step_tuning_method == "No-U":
                     # remove zeros so we don't get infs when we divide
@@ -181,7 +225,7 @@ class HamiltoneanMonteCarlo(TransitionOperator):
         if self.train_params:
             if self.tune_period is False or self.counter < self.tune_period:
                 if self.step_tuning_method == "Expected_target_prob":
-                    loss = torch.mean(U(current_q))
+                    loss = torch.mean(U(current_theta))
                 if not (torch.isinf(loss) or torch.isnan(loss)):
                     loss.backward()
                     grad_norm = torch.nn.utils.clip_grad_norm_(self.parameters(), 1)
@@ -190,30 +234,30 @@ class HamiltoneanMonteCarlo(TransitionOperator):
                     self.optimizer.step()
         if self.step_tuning_method == "No-U":
             # set next characteristc lengths
-            self.characteristic_length.data[i, :] = torch.std(current_q.detach(), dim=0)
-        return current_q.detach()  # stop gradient flow
+            self.characteristic_length.data[i, :] = torch.std(current_theta.detach(), dim=0)
+        return current_theta.detach()  # stop gradient flow
 
     def transition(self, x: torch.Tensor, log_p_x: LogProbFunc, i: int) -> torch.Tensor:
         # currently mainly written with grad_log_q_x = None in mind
         # using diagonal, would be better to use vmap (need to wait until this is released doh)
         """
-        U is potential energy, q is position, p is momentum
+        U is potential energy, theta is position, p is momentum
         """
-        current_q = x
-        def U(x: torch.Tensor):
-            return - log_p_x(x)
+        current_theta = x
+        def U(theta: torch.Tensor):
+            return - log_p_x(theta)
 
-        def grad_U(q: torch.Tensor):
-            q = q.clone().requires_grad_(True) #  need this to get gradients
-            y = U(q)
+        def grad_U(theta: torch.Tensor):
+            theta = theta.clone().requires_grad_(True) #  need this to get gradients
+            y = U(theta)
             return torch.nan_to_num(
                 torch.clamp(
-                torch.autograd.grad(y, q, grad_outputs=torch.ones_like(y))[0],
+                torch.autograd.grad(y, theta, grad_outputs=torch.ones_like(y))[0],
                 max=self.max_grad, min=-self.max_grad),
                 nan=0.0, posinf=0.0, neginf=0.0)
 
-        current_q = self.HMC_func(U, current_q, grad_U, i)
-        return current_q
+        current_theta = self.HMC_func(U, current_theta, grad_U, i)
+        return current_theta
 
 
     def save_model(self, save_path, epoch=None):

--- a/fab/sampling_methods/transition_operators/hmc_test.py
+++ b/fab/sampling_methods/transition_operators/hmc_test.py
@@ -8,14 +8,14 @@ from fab.sampling_methods.transition_operators.testing_utils import test_transit
 # HMC_STEP_TUNING_METHODS = ["p_accept", "Expected_target_prob", "No-U", "No-U-unscaled"]
 
 def test_hmc_(
-        step_tuning_method: str = HMC_STEP_TUNING_METHODS[0],
+        step_tuning_method: str = HMC_STEP_TUNING_METHODS[2],
         dim: int = 2,
         n_ais_intermediate_distributions: int = 2,
-        n_iterations: int = 50,
-        batch_size: int = 126):
+        n_iterations: int = 100,
+        batch_size: int = 64):
     mass_init = torch.ones(dim)
     hmc = HamiltoneanMonteCarlo(n_ais_intermediate_distributions=n_ais_intermediate_distributions,
-                                n_outer=5,
+                                n_outer=2,
                                 epsilon=1.0, L=5, dim=dim,
                                 step_tuning_method=step_tuning_method,
                                 mass_init=mass_init)

--- a/fab/sampling_methods/transition_operators/hmc_test.py
+++ b/fab/sampling_methods/transition_operators/hmc_test.py
@@ -8,15 +8,17 @@ from fab.sampling_methods.transition_operators.testing_utils import test_transit
 # HMC_STEP_TUNING_METHODS = ["p_accept", "Expected_target_prob", "No-U", "No-U-unscaled"]
 
 def test_hmc_(
-        step_tuning_method: str = HMC_STEP_TUNING_METHODS[2],
+        step_tuning_method: str = HMC_STEP_TUNING_METHODS[1],
         dim: int = 2,
         n_ais_intermediate_distributions: int = 2,
-        n_iterations: int = 30,
-        batch_size: int = 100):
+        n_iterations: int = 50,
+        batch_size: int = 126):
+    mass_init = torch.ones(dim)
     hmc = HamiltoneanMonteCarlo(n_ais_intermediate_distributions=n_ais_intermediate_distributions,
                                 n_outer=5,
                                 epsilon=1.0, L=5, dim=dim,
-                                step_tuning_method=step_tuning_method)
+                                step_tuning_method=step_tuning_method,
+                                mass_init=mass_init)
     test_transition_operator(transition_operator=hmc,
                              n_ais_intermediate_distributions=n_ais_intermediate_distributions,
                              dim=dim, n_iterations=n_iterations, n_samples=batch_size)

--- a/fab/sampling_methods/transition_operators/hmc_test.py
+++ b/fab/sampling_methods/transition_operators/hmc_test.py
@@ -8,7 +8,7 @@ from fab.sampling_methods.transition_operators.testing_utils import test_transit
 # HMC_STEP_TUNING_METHODS = ["p_accept", "Expected_target_prob", "No-U", "No-U-unscaled"]
 
 def test_hmc_(
-        step_tuning_method: str = HMC_STEP_TUNING_METHODS[1],
+        step_tuning_method: str = HMC_STEP_TUNING_METHODS[0],
         dim: int = 2,
         n_ais_intermediate_distributions: int = 2,
         n_iterations: int = 50,

--- a/fab/sampling_methods/transition_operators/hmc_test.py
+++ b/fab/sampling_methods/transition_operators/hmc_test.py
@@ -5,20 +5,21 @@ from fab.sampling_methods.transition_operators.hmc import HamiltoneanMonteCarlo,
     HMC_STEP_TUNING_METHODS
 from fab.sampling_methods.transition_operators.testing_utils import test_transition_operator
 
-# HMC_STEP_TUNING_METHODS = ["p_accept", "Expected_target_prob", "No-U", "No-U-unscaled"]
+# HMC_STEP_TUNING_METHODS = ["p_accept", "Expected_target_prob", "No-U"]
 
 def test_hmc_(
-        step_tuning_method: str = HMC_STEP_TUNING_METHODS[2],
+        step_tuning_method: str = HMC_STEP_TUNING_METHODS[0],
         dim: int = 2,
         n_ais_intermediate_distributions: int = 2,
-        n_iterations: int = 100,
-        batch_size: int = 64):
+        n_iterations: int = 50,
+        batch_size: int = 128):
     mass_init = torch.ones(dim)
     hmc = HamiltoneanMonteCarlo(n_ais_intermediate_distributions=n_ais_intermediate_distributions,
-                                n_outer=2,
+                                n_outer=10,
                                 epsilon=1.0, L=5, dim=dim,
                                 step_tuning_method=step_tuning_method,
-                                mass_init=mass_init)
+                                mass_init=mass_init, lr=1e-3)
     test_transition_operator(transition_operator=hmc,
                              n_ais_intermediate_distributions=n_ais_intermediate_distributions,
-                             dim=dim, n_iterations=n_iterations, n_samples=batch_size)
+                             dim=dim, n_iterations=n_iterations, n_samples=batch_size,
+                             base_scale=1.0)

--- a/fab/sampling_methods/transition_operators/testing_utils.py
+++ b/fab/sampling_methods/transition_operators/testing_utils.py
@@ -1,4 +1,5 @@
 import torch
+import numpy as np
 
 torch.autograd.set_detect_anomaly(True)
 import matplotlib.pyplot as plt
@@ -19,38 +20,39 @@ def test_transition_operator(transition_operator: TransitionOperator,
     logger = ListLogger()
     torch.manual_seed(seed)
     # instantiate base and target distribution
-    target = GMM(dim=dim, n_mixes=3, loc_scaling=8)
+    target = GMM(dim=dim, n_mixes=3, loc_scaling=6)
     learnt_sampler = torch.distributions.MultivariateNormal(loc=torch.zeros(dim),
                                                                  scale_tril=2*torch.eye(dim))
     n_intermediate_plots = 2
     n_plots = 4 + n_intermediate_plots
     fig, axs = plt.subplots(n_plots, figsize=(3, n_plots*3), sharex=True, sharey=True)
     plot_number_iterator = iter(range(n_plots))
+    plot_iter = np.linspace(0, n_iterations-1, n_intermediate_plots, dtype="int")
     for i in tqdm(range(n_iterations)):
-        x = learnt_sampler.sample_n(n_samples)  # initialise the chain
+        x = learnt_sampler.sample((n_samples, ))  # initialise the chain
         for j in range(n_ais_intermediate_distributions):
             # here we just aim for the target distribution rather than interpolating between,
             # as we are just testing the transition operator, and not AIS.
             x = transition_operator.transition(x, target.log_prob, j)
         transition_operator_info = transition_operator.get_logging_info()
         logger.write(transition_operator_info)
-        if i == 0 or i == n_iterations - 1 or i % int(n_iterations / (n_intermediate_plots + 1)) \
-                == 0:
+        if i in plot_iter:
             x = x.cpu().detach()
             plot_index = next(plot_number_iterator)
             axs[plot_index].plot(x[:, 0], x[:, 1], "o", alpha=0.5)
             axs[plot_index].set_title(f"transition operator output samples, iteration {i}")
             fig.show()
 
+    # TODO: fix plotting here
     true_samples = target.sample((n_samples,)).cpu().detach()
     plot_index = next(plot_number_iterator)
     axs[plot_index].plot(true_samples[:, 0], true_samples[:, 1], "o", alpha=0.5)
     axs[plot_index].set_title("true samples")
 
-    sampler_samples = learnt_sampler.sample_n(n_samples).cpu().detach()
+    sampler_samples = learnt_sampler.sample((n_samples,)).cpu().detach()
     plot_index = next(plot_number_iterator)
     axs[plot_index].plot(sampler_samples[:, 0], sampler_samples[:, 1], "o", alpha=0.5)
-    axs[plot_index].set_title("sampler samples")
+    axs[plot_index].set_title("base dist samples")
     plt.tight_layout()
     fig.show()
 

--- a/fab/sampling_methods/transition_operators/testing_utils.py
+++ b/fab/sampling_methods/transition_operators/testing_utils.py
@@ -23,8 +23,8 @@ def test_transition_operator(transition_operator: TransitionOperator,
     target = GMM(dim=dim, n_mixes=3, loc_scaling=6)
     learnt_sampler = torch.distributions.MultivariateNormal(loc=torch.zeros(dim),
                                                                  scale_tril=2*torch.eye(dim))
-    n_intermediate_plots = 2
-    n_plots = 4 + n_intermediate_plots
+    n_intermediate_plots = 4  # plots of samples over different HMC iterations
+    n_plots = 2 + n_intermediate_plots
     fig, axs = plt.subplots(n_plots, figsize=(3, n_plots*3), sharex=True, sharey=True)
     plot_number_iterator = iter(range(n_plots))
     plot_iter = np.linspace(0, n_iterations-1, n_intermediate_plots, dtype="int")
@@ -43,7 +43,6 @@ def test_transition_operator(transition_operator: TransitionOperator,
             axs[plot_index].set_title(f"transition operator output samples, iteration {i}")
             fig.show()
 
-    # TODO: fix plotting here
     true_samples = target.sample((n_samples,)).cpu().detach()
     plot_index = next(plot_number_iterator)
     axs[plot_index].plot(true_samples[:, 0], true_samples[:, 1], "o", alpha=0.5)

--- a/fab/sampling_methods/transition_operators/testing_utils.py
+++ b/fab/sampling_methods/transition_operators/testing_utils.py
@@ -16,13 +16,16 @@ def test_transition_operator(transition_operator: TransitionOperator,
                              n_iterations: int = 20,
                              n_samples: int = 1000,
                              dim: int = 2,
-                             seed: int = 0) -> None:
+                             seed: int = 0,
+                             base_scale: float = 1.0) -> None:
     logger = ListLogger()
     torch.manual_seed(seed)
     # instantiate base and target distribution
-    target = GMM(dim=dim, n_mixes=3, loc_scaling=6)
+    target_scale = 5.0
+    target = GMM(dim=dim, n_mixes=3, loc_scaling=target_scale)
+    base_scale = base_scale * target_scale
     learnt_sampler = torch.distributions.MultivariateNormal(loc=torch.zeros(dim),
-                                                                 scale_tril=2*torch.eye(dim))
+                                                                 scale_tril=base_scale*torch.eye(dim))
     n_intermediate_plots = 4  # plots of samples over different HMC iterations
     n_plots = 2 + n_intermediate_plots
     fig, axs = plt.subplots(n_plots, figsize=(3, n_plots*3), sharex=True, sharey=True)

--- a/fab/target_distributions/__init__.py
+++ b/fab/target_distributions/__init__.py
@@ -1,0 +1,1 @@
+from fab.target_distributions.base import TargetDistribution

--- a/fab/utils/numerical.py
+++ b/fab/utils/numerical.py
@@ -39,8 +39,3 @@ def importance_weighted_expectation(f: Callable[[torch.Tensor], torch.Tensor], x
     function_values = f(x)
     expectation = normalised_importance_weights.T @ function_values
     return expectation
-
-
-
-
-

--- a/fab/utils/plotting.py
+++ b/fab/utils/plotting.py
@@ -29,7 +29,7 @@ def plot_history(history):
 
 def plot_contours(log_prob_func: LogProbFunc,
                   ax: Optional[plt.Axes] = None,
-                  bounds: Tuple[int, int] = (-5, 5),
+                  bounds: Tuple[float, float] = (-5.0, 5.0),
                   grid_width_n_points: int = 20,
                   n_contour_levels: Optional[int] = None):
     """Plot contours of a log_prob_func that is defined on 2D"""
@@ -51,10 +51,11 @@ def plot_contours(log_prob_func: LogProbFunc,
 def plot_marginal_pair(samples: torch.Tensor,
                   ax: Optional[plt.Axes] = None,
                   marginal_dims: Tuple[int, int] = (0, 1),
-                  bounds: Tuple[int, int] = (-5, 5),):
+                  bounds: Tuple[float, float] = (-5.0, 5.0),
+                  alpha: float = 0.5):
     """Plot samples from marginal of distribution for a given pair of dimensions."""
     if not ax:
         fig, ax = plt.subplots(1)
     samples = torch.clamp(samples, bounds[0], bounds[1])
     samples = samples.cpu().detach()
-    ax.plot(samples[:, marginal_dims[0]], samples[:, marginal_dims[1]], "o", alpha=0.5)
+    ax.plot(samples[:, marginal_dims[0]], samples[:, marginal_dims[1]], "o", alpha=alpha)


### PR DESCRIPTION
Solves #17 
 - Add option to specify the mass matrix, instead of always assuming unit mass.
 - Clean up HMC code, making it more modular
 - Add an option for evaluation mode where none HMC's parameters are tuned.
 - Add example notebook visualising AIS, including the effect of the number of distributions on the sample size.


Currently the p_accept method of tuning HMC seems to be working fine (see AIS notebook in examples).
However maximising the expected target log-prob method leads to mode hugging and performs poorly. This mode hugging could potentially be prevented by having a longer chain or just a bug in my implementation.
I am going to leave this for a future issue (e.g. if/when we decide that a better tuning method for HMC is important).