### PR TITLE
Minor bug fix: parameter map output shape for odd dimension problem

### DIFF
--- a/experiments/make_flow/make_normflow_model.py
+++ b/experiments/make_flow/make_normflow_model.py
@@ -18,8 +18,8 @@ def make_normflow_flow(dim: int,
     for i in range(n_flow_layers):
         # Neural network with two hidden layers having 32 units each
         # Last layer is initialized by zeros making training more stable
-        param_map = nf.nets.MLP([int((dim / 2) + 0.5), layer_width, layer_width, dim],
-                                init_zeros=True)
+        d = int((dim / 2) + 0.5)
+        param_map = nf.nets.MLP([d, layer_width, layer_width, 2 * (dim - d)], init_zeros=True)
         # Add flow layer
         flows.append(nf.flows.AffineCouplingBlock(param_map, scale_map="exp"))
         # Swap dimensions
@@ -49,7 +49,8 @@ def make_normflow_snf(base: nf.distributions.BaseDistribution,
     for i in range(n_flow_layers):
         # Neural network with two hidden layers having 32 units each
         # Last layer is initialized by zeros making training more stable
-        param_map = nf.nets.MLP([int((dim / 2) + 0.5), layer_width, layer_width, dim], init_zeros=True)
+        d = int((dim / 2) + 0.5)
+        param_map = nf.nets.MLP([d, layer_width, layer_width, 2 * (dim - d)], init_zeros=True)
         # Add flow layer
         flows.append(nf.flows.AffineCouplingBlock(param_map, scale_map="exp"))
         # Swap dimensions


### PR DESCRIPTION
When the problem dimension is odd, we still need an even number of parameters so that half can be assigned to shift and half to scale. This commit generalises the expression for the final parameter map dimension so that it works in odd and even cases.