### PR TITLE
fix: naming of metric in Many Well

### DIFF
--- a/experiments/config/many_well.yaml
+++ b/experiments/config/many_well.yaml
@@ -60,6 +60,11 @@ evaluation:
 
 
 logger:
-  pandas_logger:
-    save_period: 1000 # how often to save the pandas dataframe as a csv
+  wandb:
+    name: Manywell
+    project: fab
+    entity: flow-ais-bootstrap
+    tags: [many_well]
+#  pandas_logger:
+#    save_period: 1000 # how often to save the pandas dataframe as a csv
 

--- a/experiments/config/many_well.yaml
+++ b/experiments/config/many_well.yaml
@@ -36,7 +36,7 @@ training:
   lr: 3e-4
   batch_size: 100
   n_iterations: null
-  n_flow_forward_pass: 10_000_000_00
+  n_flow_forward_pass: 10_000_000_000
   use_gpu: true
   use_64_bit: true
   use_buffer: false

--- a/experiments/config/many_well.yaml
+++ b/experiments/config/many_well.yaml
@@ -34,9 +34,9 @@ training:
   checkpoint_load_dir: null # or null
   seed: 0
   lr: 3e-4
-  batch_size: 2048
+  batch_size: 100
   n_iterations: null
-  n_flow_forward_pass: 10_000_000_000
+  n_flow_forward_pass: 10_000_000_00
   use_gpu: true
   use_64_bit: true
   use_buffer: false
@@ -53,7 +53,7 @@ training:
 evaluation:
   n_plots: 50 # number of times we visualise the model throughout training.
   n_eval: 50 # for calculating metrics of flow w.r.t target.
-  eval_batch_size: 2048 # must be a multiple of inner batch size
+  eval_batch_size: 1000 # must be a multiple of inner batch size
   n_checkpoints: 10 # number of model checkpoints saved
   save_path:  ./results/many_well/seed${training.seed}/
 

--- a/experiments/config/many_well.yaml
+++ b/experiments/config/many_well.yaml
@@ -34,9 +34,9 @@ training:
   checkpoint_load_dir: null # or null
   seed: 0
   lr: 3e-4
-  batch_size: 100
+  batch_size: 2048
   n_iterations: null
-  n_flow_forward_pass: 10_000_000_0
+  n_flow_forward_pass: 10_000_000_000
   use_gpu: true
   use_64_bit: true
   use_buffer: false
@@ -53,18 +53,13 @@ training:
 evaluation:
   n_plots: 50 # number of times we visualise the model throughout training.
   n_eval: 50 # for calculating metrics of flow w.r.t target.
-  eval_batch_size: 1000 # must be a multiple of inner batch size
+  eval_batch_size: 2048 # must be a multiple of inner batch size
   n_checkpoints: 10 # number of model checkpoints saved
   save_path:  ./results/many_well/seed${training.seed}/
 
 
 
 logger:
-  wandb:
-    name: Manywell
-    project: fab
-    entity: flow-ais-bootstrap
-    tags: [many_well]
-#  pandas_logger:
-#    save_period: 1000 # how often to save the pandas dataframe as a csv
+  pandas_logger:
+    save_period: 1000 # how often to save the pandas dataframe as a csv
 

--- a/experiments/config/many_well.yaml
+++ b/experiments/config/many_well.yaml
@@ -36,7 +36,7 @@ training:
   lr: 3e-4
   batch_size: 100
   n_iterations: null
-  n_flow_forward_pass: 10_000_000_000
+  n_flow_forward_pass: 10_000_000_0
   use_gpu: true
   use_64_bit: true
   use_buffer: false

--- a/experiments/many_well/run.py
+++ b/experiments/many_well/run.py
@@ -65,7 +65,7 @@ def _run(cfg: DictConfig):
     setup_trainer_and_run_flow(cfg, setup_many_well_plotter, target)
 
 
-@hydra.main(config_path="../config", config_name="many_well_fast.yaml")
+@hydra.main(config_path="../config", config_name="many_well.yaml")
 def run(cfg: DictConfig):
     _run(cfg)
 

--- a/experiments/many_well/run.py
+++ b/experiments/many_well/run.py
@@ -65,7 +65,7 @@ def _run(cfg: DictConfig):
     setup_trainer_and_run_flow(cfg, setup_many_well_plotter, target)
 
 
-@hydra.main(config_path="../config", config_name="many_well.yaml")
+@hydra.main(config_path="../config", config_name="many_well_fast.yaml")
 def run(cfg: DictConfig):
     _run(cfg)
 

--- a/fab/target_distributions/many_well.py
+++ b/fab/target_distributions/many_well.py
@@ -102,12 +102,17 @@ class ManyWellEnergy(DoubleWellEnergy, TargetDistribution):
         n_vals_per_split = log_w.shape[0] // n_runs
         log_w = log_w[:n_vals_per_split*n_runs]
         log_w = torch.stack(log_w.split(n_runs), dim=-1)
+
         # Check accuracy in estimating normalisation constant.
         log_Z_estimate = torch.logsumexp(log_w, dim=-1) - np.log(log_w.shape[-1])
         relative_error = torch.exp(log_Z_estimate - self.log_Z) - 1
         MSE_Z_estimate = torch.mean(torch.abs(relative_error))
 
-        info = {"MSE_log_Z_estimate": MSE_Z_estimate.cpu().item()}
+        abs_MSE_log_Z_estimate = jnp.mean(jnp.abs(log_Z_estimate - self.log_Z))
+
+        info = {}
+        info.update(relative_MSE_Z_estimate=MSE_Z_estimate.cpu().item())
+        info.update(abs_MSE_log_Z_estimate=abs_MSE_log_Z_estimate.cpu().item())
 
         if log_q_fn is not None:
             # Used later for estimation of test set probabilities.

--- a/fab/target_distributions/many_well.py
+++ b/fab/target_distributions/many_well.py
@@ -108,7 +108,7 @@ class ManyWellEnergy(DoubleWellEnergy, TargetDistribution):
         relative_error = torch.exp(log_Z_estimate - self.log_Z) - 1
         MSE_Z_estimate = torch.mean(torch.abs(relative_error))
 
-        abs_MSE_log_Z_estimate = jnp.mean(jnp.abs(log_Z_estimate - self.log_Z))
+        abs_MSE_log_Z_estimate = torch.mean(torch.abs(log_Z_estimate - self.log_Z))
 
         info = {}
         info.update(relative_MSE_Z_estimate=MSE_Z_estimate.cpu().item())


### PR DESCRIPTION
Many well metric was incorrectly named `MSE_log_Z estimate` when it should be `relative_MSE_Z_estimate`. Additionally we now also include the MSE for the estimation of the log normalizing constant. 